### PR TITLE
Architected code that transitions this from modified example to professional codebase foundation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -164,18 +164,23 @@ myclean: mystop
 	@echo "Clean Done"
 
 
+
+
+
+
+
 .PHONY: create
 create: createConfigmap createDeployment createService createIngress
 	@echo "Creation Completed"
 
 .PHONY: delete
-create: deleteConfigmap deleteDeployment deleteService deleteIngress
+delete: deleteConfigmap deleteDeployment deleteService deleteIngress
 	@echo "Deletion Completed"
 
 .PHONY: createConfigmap
 createConfigmap:
-	-kubectl create configmap mysqlconfig --from-file ./ignoredir/mysql.cnf
-	-kubectl create configmap mysqlsecurecheck --from-file ./ignoredir/blank.cnf
+	-kubectl create configmap mysqlconfig --from-file ./config/samples/cnf/mysql.cnf
+	-kubectl create configmap mysqlsecurecheck --from-file ./config/samples/cnf/blank.cnf
 
 .PHONY: createDeployment
 createDeployment:
@@ -183,11 +188,11 @@ createDeployment:
 
 .PHONY: createService
 createService:
-	-kubectl apply -f ./ignoredir/wordpress_service.yaml
+	-kubectl apply -f ./config/samples/service/wordpress_service.yaml
 
 .PHONY: createIngress
 createIngress:
-	-kubectl apply -f ./ignoredir/ingress.yaml
+	-kubectl apply -f ./config/samples/ingress/wordpress_ingress.yaml
 
 
 
@@ -202,11 +207,11 @@ deleteDeployment:
 
 .PHONY: deleteService
 deleteService:
-	-kubectl delete --ignore-not-found=true -f ./ignoredir/wordpress_service.yaml
+	-kubectl delete --ignore-not-found=true -f ./config/samples/service/wordpress_service.yaml
 
 .PHONY: deleteIngress
 deleteIngress:
-	-kubectl apply -f ./ignoredir/ingress.yaml
+	-kubectl apply -f ./config/samples/ingress/wordpress_ingress.yaml
 
 
 .PHONY: describeConfigmap

--- a/api/v1/wordpress_types.go
+++ b/api/v1/wordpress_types.go
@@ -29,6 +29,7 @@ type WordpressSpec struct {
 	// Important: Run "make" to regenerate code after modifying this file
 
 	// Foo is an example field of Wordpress. Edit Wordpress_types.go to remove/update
+	AppName  string `json:"AppName"`
 	Password string `json:"password"`
 }
 

--- a/config/crd/bases/wordpress-fullstack.jamesmoore.in_wordpresses.yaml
+++ b/config/crd/bases/wordpress-fullstack.jamesmoore.in_wordpresses.yaml
@@ -36,11 +36,14 @@ spec:
         spec:
           description: WordpressSpec defines the desired state of Wordpress
           properties:
-            password:
+            AppName:
               description: Foo is an example field of Wordpress. Edit Wordpress_types.go
                 to remove/update
               type: string
+            password:
+              type: string
           required:
+          - AppName
           - password
           type: object
         status:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -19,7 +19,14 @@ rules:
   - update
   - watch
 - apiGroups:
-  - cache.example.com
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - wordpress-fullstack.jamesmoore.in
   resources:
   - wordpresss
   verbs:
@@ -31,17 +38,10 @@ rules:
   - update
   - watch
 - apiGroups:
-  - cache.example.com
+  - wordpress-fullstack.jamesmoore.in
   resources:
   - wordpresss/status
   verbs:
   - get
   - patch
   - update
-- apiGroups:
-  - ""
-  resources:
-  - pods
-  verbs:
-  - get
-  - list

--- a/config/samples/wordpress-fullstack_v1_wordpress.yaml
+++ b/config/samples/wordpress-fullstack_v1_wordpress.yaml
@@ -4,4 +4,5 @@ metadata:
   name: wordpress-moorej10
 spec:
   # Add fields here
+  AppName: James-Test
   password: p

--- a/controllers/common/common.go
+++ b/controllers/common/common.go
@@ -1,0 +1,80 @@
+package common
+
+import (
+	"context"
+	wordpressfullstackv1 "github.com/James-Moore/wordpress-operator/api/v1"
+	"github.com/go-logr/logr"
+	v1 "k8s.io/api/apps/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// +kubebuilder:rbac:groups=wordpress-fullstack.jamesmoore.in,resources=wordpresss,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=wordpress-fullstack.jamesmoore.in,resources=wordpresss/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=core,resources=pods,verbs=get;list;
+type Common struct {
+	Client    client.Client
+	Log       logr.Logger
+	Scheme    *runtime.Scheme
+	Ctx       context.Context
+	Wordpress *wordpressfullstackv1.Wordpress
+}
+
+func (common *Common) Init(namespaceName types.NamespacedName) (breakControl bool, err error) {
+	breakControl = false
+	err = nil
+
+	err = common.Client.Get(common.Ctx, namespaceName, common.Wordpress)
+	if err != nil {
+		breakControl = true
+
+		if errors.IsNotFound(err) {
+			// Request custom resource not found, could have been deleted after reconcile request.
+			// Owned objects are automatically garbage collected. For additional cleanup logic use finalizers.
+			// Return and don't requeue
+			common.Log.Info("Wordpress resource not found. Ignoring since object must be deleted")
+			err = nil
+			return breakControl, err
+		} else {
+			//The custom resource may exist.  We dont know in this case because an error was thrown while
+			//attempting cr retrieval.  Therefore we have to break control loop and exit.
+			common.Log.Error(err, "Failed to get Wordpress")
+			return breakControl, err
+		}
+	}
+
+	//Wordpress CR was retrieved successfully so do not break control loop.
+	return breakControl, err
+}
+
+func (common *Common) GetNamespace() string {
+	return common.Wordpress.Namespace
+}
+func (common *Common) GetApplicationName() string {
+	return common.Wordpress.Spec.AppName
+}
+func (common *Common) GetCustomResourceType() string {
+	return common.Wordpress.Kind
+}
+func (common *Common) GetCustomResourceValue() string {
+	return common.Wordpress.Name
+}
+func (common *Common) GetDeployment() (*v1.Deployment, error) {
+	deployment := &v1.Deployment{}
+	err := common.Client.Get(common.Ctx, common.GetNamespacedName(), deployment)
+	return deployment, err
+}
+
+// Returns the labels for selecting the resources
+func (common *Common) GetSelectionLabels(tier string) map[string]string {
+	//Example: map[string]string{"app": "mywordpressapp", "wordpress_cr": "mywordpress"}
+	return map[string]string{APPLICATION_KEY: common.GetApplicationName(), common.GetCustomResourceType(): common.GetCustomResourceValue(), TIER_KEY: tier}
+}
+
+// Returns the NamespacedName for selecting the resources
+func (common *Common) GetNamespacedName() types.NamespacedName {
+	return types.NamespacedName{Namespace: common.GetNamespace(), Name: common.GetCustomResourceValue()}
+}

--- a/controllers/common/constants.go
+++ b/controllers/common/constants.go
@@ -1,0 +1,34 @@
+package common
+
+const (
+	CURRENT_APPLICATION_TIERING = TIER_FULLSTACK
+
+	WORDPRESS_APP_NAME       = "wordpress_on_sql"
+	WORDPRESS_CONTAINER_NAME = "wordpress"
+	WORDPRESS_IMAGE_NAME     = "wordpress"
+	MYSQL_CONTAINER_NAME     = "mysql"
+	MYSQL_IMAGE_NAME         = "mysql"
+
+	MYSQL_MYSQLCNF_CONFIGMAP_KEY    = "mysqlconfig"
+	MySQL_MYSQLCNF_CONFIGMAP_VOLUME = "mysqlconfigvolume"
+	MYSQL_MYSQLCNF_CONFIGMAP_PATH   = "/etc/mysql"
+	MYSQL_MYSQLCNF_CONFIG_FILE      = "mysql.cnf"
+
+	MYSQL_SECURECHK_CONFIGMAP_KEY    = "mysqlsecurecheck"
+	MYSQL_SECURECHK_CONFIGMAP_VOLUME = "mysqlsecurecheckvolume"
+	MYSQL_SECURECHK_CONFIGMAP_PATH   = "/var/lib/mysql-files"
+	MYSQL_SECURECHK_CONFIGMAP_FILE   = "blank.cnf"
+
+	MYSQL_PORT_STRING = "3306"
+	MYSQL_PORT_INT32  = 3306
+
+	SERVICE_NAME = "wpservice"
+)
+
+const (
+	APPLICATION_KEY = "app"
+	TIER_KEY        = "tier"
+	TIER_FRONTEND   = "front"
+	TIER_BACKEND    = "back"
+	TIER_FULLSTACK  = "fullstack"
+)

--- a/controllers/configmap/config_loader.go
+++ b/controllers/configmap/config_loader.go
@@ -1,0 +1,18 @@
+package configmap
+
+import (
+	"github.com/ghodss/yaml"
+	"io/ioutil"
+)
+
+type Config struct {
+	Message string `yaml:"message"`
+}
+
+func (configMap *Config) LoadConfig(configFile string) (err error) {
+	err = nil
+
+	configData, err := ioutil.ReadFile(configFile)
+	err = yaml.Unmarshal(configData, configMap)
+	return err
+}

--- a/controllers/configmap/configmap_creator.go
+++ b/controllers/configmap/configmap_creator.go
@@ -1,0 +1,33 @@
+package configmap
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"os"
+)
+
+type ConfigMapFileTemplate struct {
+	Namespace string
+	Mapkey    string
+	Directory string
+	File      string
+}
+
+func (template *ConfigMapFileTemplate) createConfigmap() (configMap corev1.ConfigMap, err error) {
+	config := Config{}
+
+	err = nil
+	err = config.LoadConfig(template.Directory + string(os.PathSeparator) + template.File)
+
+	configMap = corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      template.Mapkey,
+			Namespace: template.Namespace,
+		},
+		Data: map[string]string{
+			template.File: config.Message,
+		},
+	}
+
+	return configMap, err
+}

--- a/controllers/deployment/deployment_manager.go
+++ b/controllers/deployment/deployment_manager.go
@@ -1,0 +1,221 @@
+package deployment
+
+import (
+	wordpressfullstackv1 "github.com/James-Moore/wordpress-operator/api/v1"
+	"github.com/James-Moore/wordpress-operator/controllers/common"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+type DeploymentManager struct {
+	C *common.Common
+}
+
+// deploymentForWordpress returns a Wordpress Deployment object
+func (manager *DeploymentManager) populateDeployment(containers []corev1.Container) (deployment *appsv1.Deployment) {
+	deployment = &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      manager.C.Wordpress.Name,
+			Namespace: manager.C.Wordpress.Namespace,
+		},
+		Spec: appsv1.DeploymentSpec{
+			//Replicas: replicas,
+			Selector: &metav1.LabelSelector{
+				MatchLabels: manager.C.GetSelectionLabels(common.CURRENT_APPLICATION_TIERING),
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: manager.C.GetSelectionLabels(common.CURRENT_APPLICATION_TIERING),
+				},
+				Spec: corev1.PodSpec{
+					Volumes: []corev1.Volume{{
+						Name: common.MySQL_MYSQLCNF_CONFIGMAP_VOLUME,
+						VolumeSource: corev1.VolumeSource{
+							ConfigMap: &corev1.ConfigMapVolumeSource{
+								LocalObjectReference: corev1.LocalObjectReference{Name: common.MYSQL_MYSQLCNF_CONFIGMAP_KEY},
+								Items: []corev1.KeyToPath{{
+									Key:  common.MYSQL_MYSQLCNF_CONFIG_FILE,
+									Path: common.MYSQL_MYSQLCNF_CONFIG_FILE,
+								}},
+							},
+						},
+					},
+						{
+							Name: common.MYSQL_SECURECHK_CONFIGMAP_VOLUME,
+							VolumeSource: corev1.VolumeSource{
+								ConfigMap: &corev1.ConfigMapVolumeSource{
+									LocalObjectReference: corev1.LocalObjectReference{Name: common.MYSQL_SECURECHK_CONFIGMAP_KEY},
+									Items: []corev1.KeyToPath{{
+										Key:  common.MYSQL_SECURECHK_CONFIGMAP_FILE,
+										Path: common.MYSQL_SECURECHK_CONFIGMAP_FILE,
+									}},
+								},
+							},
+						}},
+					Containers: containers,
+				},
+			},
+		},
+	}
+	return deployment
+}
+
+func (manager *DeploymentManager) updateStatus(deployment *appsv1.Deployment, wordpressContainer *corev1.Container, mysqlContainer *corev1.Container) {
+	//TODO potentially assign Wordpress CR UID to Deployment as a label to allow searching for only this object
+	//Assign the Wordpress Deployment data to the status
+	manager.C.Wordpress.Status.WordpressDeploymentName = deployment.Name
+	manager.C.Wordpress.Status.WordpressDeploymentNamespace = deployment.Namespace
+	manager.C.Wordpress.Status.WordpressDeploymentUUID = string(deployment.UID)
+
+	//Assign the Wordpress pod data to the CR status
+	manager.C.Wordpress.Status.WordpressPodName = deployment.Spec.Template.Name
+	manager.C.Wordpress.Status.WordpressPodNamespace = deployment.Spec.Template.Namespace
+	manager.C.Wordpress.Status.WordpressPodUID = string(deployment.Spec.Template.UID)
+
+	//Assign the mysql container name to the cr status
+	//Note: We can index zero here only because we created the array and we know there is only 1 container
+	manager.C.Wordpress.Status.WordpressContainerName = wordpressContainer.Name
+	manager.C.Wordpress.Status.MySqlContainerName = mysqlContainer.Name
+}
+
+func (manager *DeploymentManager) Reconcile() (bool, error) {
+	breakControl := false
+
+	// Check if the Deployment already exists, if not create a new one
+	deployment, err := manager.C.GetDeployment()
+	if err != nil {
+		manager.C.Log.Info("MADE IT HERE AT LEAST ONCE")
+
+		//If the Deployment is not found create the Deployment and disregard the error.  This is expected behavior.
+		if errors.IsNotFound(err) {
+
+			// DEBUG
+
+			// Define containers to be deployed
+			wordpressContainer := manager.DefineWordpressContainer(manager.C.Wordpress)
+			mysqlContainer := manager.DefineMySqlContainer(manager.C.Wordpress)
+			containers := []corev1.Container{wordpressContainer, mysqlContainer}
+
+			// Populate the Deployment object
+			deployment = manager.populateDeployment(containers)
+
+			// Set Wordpress instance as the owner and controller
+			_ = ctrl.SetControllerReference(manager.C.Wordpress, deployment, manager.C.Scheme)
+
+			// Create the containers
+			manager.C.Log.Info("Creating a new Deployment", "Deployment.Namespace", deployment.Namespace, "Deployment.Name", deployment.Name)
+			err = manager.C.Client.Create(manager.C.Ctx, deployment)
+			if err != nil {
+				breakControl = true
+				manager.C.Log.Error(err, "Failed to create new Deployment", "Deployment.Namespace", deployment.Namespace, "Deployment.Name", deployment.Name)
+				return breakControl, err
+			}
+
+			manager.updateStatus(deployment, &wordpressContainer, &mysqlContainer)
+
+			//Must update Wordpress cr to include added status values
+			err := manager.C.Client.Status().Update(manager.C.Ctx, manager.C.Wordpress)
+			if err != nil {
+				breakControl = true
+				manager.C.Log.Error(err, "Failed to update Wordpress status")
+				return breakControl, err
+			}
+
+			// Deployment created successfully - disregard err - return and requeue
+			err = nil
+			return breakControl, err
+
+		} else {
+			//If the error is the result of anyting but not finding the Deployment then
+			//an error was encountered when trying to get the Deployment.  So exit control loop.
+			breakControl = true
+			//manager.C.Log.Error(err, "Failed to get Deployment")
+			return breakControl, err
+		}
+
+	}
+
+	//If we have arrived here then we have not encountered an error
+	//We have succesfully retrieved the Deployment.  So continue control loop.
+	return breakControl, err
+}
+
+func (manager *DeploymentManager) DefineWordpressContainer(m *wordpressfullstackv1.Wordpress) corev1.Container {
+
+	wordpressContainer := corev1.Container{
+		Name:  common.WORDPRESS_CONTAINER_NAME,
+		Image: common.WORDPRESS_IMAGE_NAME,
+		Ports: []corev1.ContainerPort{{
+			Name:          "wordpress",
+			ContainerPort: 80,
+		}},
+		Env: []corev1.EnvVar{
+			{
+				Name:  "WORDPRESS_DB_HOST",
+				Value: common.SERVICE_NAME + ":" + common.MYSQL_PORT_STRING,
+			},
+			{
+				Name:  "WORDPRESS_DB_USER",
+				Value: "root",
+			},
+			{
+				Name:  "WORDPRESS_DB_PASSWORD",
+				Value: m.Spec.Password,
+			},
+			{
+				Name:  "WORDPRESS_DB_NAME",
+				Value: "wordpress",
+			},
+			{
+				Name:  "WORDPRESS_TABLE_PREFIX",
+				Value: "wp_",
+			},
+		},
+	}
+	return wordpressContainer
+}
+
+func (manager *DeploymentManager) DefineMySqlContainer(m *wordpressfullstackv1.Wordpress) corev1.Container {
+
+	probeAction := &corev1.ExecAction{
+		Command: []string{"mysqladmin", "ping", "-u", "root", "-p${MYSQL_ROOT_PASSWORD}"},
+	}
+
+	probeHandler := corev1.Handler{
+		Exec: probeAction,
+	}
+
+	readinessProbe := &corev1.Probe{
+		Handler:             probeHandler,
+		InitialDelaySeconds: 20,
+		PeriodSeconds:       10,
+	}
+
+	mysqlContainer := corev1.Container{
+		Name:  common.MYSQL_CONTAINER_NAME,
+		Image: common.MYSQL_IMAGE_NAME,
+		Ports: []corev1.ContainerPort{{
+			Name:          "mysql",
+			ContainerPort: common.MYSQL_PORT_INT32,
+		}},
+		Env: []corev1.EnvVar{{
+			Name:  "MYSQL_ROOT_PASSWORD",
+			Value: m.Spec.Password,
+		}},
+		VolumeMounts: []corev1.VolumeMount{{
+			Name:      common.MySQL_MYSQLCNF_CONFIGMAP_VOLUME,
+			MountPath: common.MYSQL_MYSQLCNF_CONFIGMAP_PATH,
+		},
+			{
+				Name:      common.MYSQL_SECURECHK_CONFIGMAP_VOLUME,
+				MountPath: common.MYSQL_SECURECHK_CONFIGMAP_PATH,
+			},
+		},
+		ReadinessProbe: readinessProbe,
+	}
+
+	return mysqlContainer
+}

--- a/controllers/pod/pod_manager.go
+++ b/controllers/pod/pod_manager.go
@@ -1,0 +1,160 @@
+package pod
+
+import (
+	"github.com/James-Moore/wordpress-operator/controllers/common"
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"strconv"
+)
+
+type PodManager struct {
+	Common *common.Common
+}
+
+func (manager *PodManager) getPodState(pod corev1.Pod) string {
+	message := "Pod: " + pod.Name
+	for _, containerStatus := range pod.Status.ContainerStatuses {
+		message = message + ", Container: " + containerStatus.Name + "State: " + containerStatus.State.String()
+	}
+	return message
+}
+
+func (manager *PodManager) getPodsState(pods []corev1.Pod) string {
+	message := "Pods: "
+	for _, pod := range pods {
+		message += manager.getPodState(pod)
+	}
+	return message
+}
+
+func (manager *PodManager) containsContainer(containerName string, pod corev1.Pod) bool {
+	for _, cs := range pod.Status.ContainerStatuses {
+		if containerName == cs.Name {
+			return true
+		}
+	}
+	return false
+}
+
+func (manager *PodManager) isContainerInPodReady(containerName string, pod corev1.Pod) bool {
+	ready := false
+	for _, cs := range pod.Status.ContainerStatuses {
+		if containerName == cs.Name {
+			ready = cs.Ready
+		}
+	}
+	return ready
+}
+
+//MYSQL_CONTAINER_NAME
+func (manager *PodManager) isContainerInPodsReady(containerName string, podName string, pods []corev1.Pod) bool {
+	ready := false
+
+	manager.Common.Log.Info(manager.getPodsState(pods))
+	for _, pod := range pods {
+		if (podName == pod.Name) && (manager.containsContainer(containerName, pod)) {
+			ready = manager.isContainerInPodReady(containerName, pod)
+			manager.Common.Log.Info("MySql Ready: " + strconv.FormatBool(ready))
+			return ready
+		}
+	}
+
+	return ready
+}
+
+func (manager *PodManager) Reconcile() (breakControl bool, err error) {
+	breakControl = false
+	err = nil
+
+	podList := &corev1.PodList{}
+	breakControl, err = manager.getPodList(podList)
+	if err != nil {
+		manager.Common.Log.Error(err, "Could not retrieve pods from deployment while Reconciling.")
+		breakControl = true
+		return breakControl, err
+	}
+
+	// TODO Get container name and pod name from the wordpress status to feed into isContainerPodsReady
+	podName := manager.Common.Wordpress.Status.WordpressPodName
+	mysqlContainerName := manager.Common.Wordpress.Status.MySqlContainerName
+	mysqlReady := manager.isContainerInPodsReady(podName, mysqlContainerName, podList.Items)
+
+	//Nothing to reconcile if mysql is still booting in the container
+	if !mysqlReady {
+		manager.Common.Log.Info("MySQL is ready: " + strconv.FormatBool(mysqlReady))
+		breakControl = true
+		return breakControl, err
+	}
+
+	manager.Common.Log.Info("MySQL is ready: " + strconv.FormatBool(mysqlReady))
+
+	// TODO Add wordpress to deployment here
+	//, r.defineWordpressContainer(wordpress)
+
+	//podNames := getPodNames(podList.Items)
+	//Development statement:  Printing all pod names
+	//r.Log.Info("PRINTING POD NAMES: ")
+	//for podName, _ := range podNames {
+	//	r.Log.Info(podName)
+	//}
+
+	//switch os := len(podNames); os {
+	//case 0:
+	//	err := errors2.New("wordpress pod reconciliation error")
+	//	r.Log.Error(err, "WordpressContainer and MySQLContainer do not exist in deployment.  This should never happen.", "Wordpress.Namespace", wordpress.Namespace, "Wordpress.Name", wordpress.Name)
+	//	return err
+	//case 1:
+	//	if _, ok := podNames[WORDPRESS_IMAGE_NAME]; !ok {
+	//		err := errors2.New("wordpress pod reconciliation error")
+	//		r.Log.Error(err, "WordpressContainer exists without MySQLContainer.  This should never happen.", "Wordpress.Namespace", wordpress.Namespace, "Wordpress.Name", wordpress.Name)
+	//		return err
+	//	}
+	//	// TODO Update Deployment Definition here to include the wordpress container in the Pod.
+	//	// This becasue the mysqlpod is up and running
+	//default:
+	//	if os > 2 {
+	//		err := errors2.New("wordpress pod reconciliation error")
+	//		num := strconv.Itoa(os)
+	//		r.Log.Error(err, "There are additional pods that shoudl not exist in the Wordpress Deployment.  Number of pods are: "+num+".This should never happen.", "Wordpress.Namespace", wordpress.Namespace, "Wordpress.Name", wordpress.Name)
+	//		return err
+	//	}
+	//}
+
+	//Everything went fine.
+	return false, nil
+}
+
+// getPodNames returns the pod names of the array of pods passed in
+func (manager *PodManager) getPodNames(pods []corev1.Pod) map[string]bool {
+	podNames := make(map[string]bool) // New empty set
+	//delete(podNames, "Foo")    // Delete
+	//exists := podNames["Foo"]  // Membership
+
+	for _, pod := range pods {
+		podNames[pod.Name] = true // Add
+	}
+	return podNames
+}
+
+func (manager *PodManager) getPodList(podList *corev1.PodList) (breakControl bool, err error) {
+	breakControl = false
+	err = nil
+
+	// Define the values to match Pods against
+	listOpts := []client.ListOption{
+		client.InNamespace(manager.Common.Wordpress.Namespace),
+		client.MatchingLabels(manager.Common.GetSelectionLabels(common.CURRENT_APPLICATION_TIERING)),
+	}
+
+	// Get the list of pods matching our search parameters: Namespace and Labels
+	err = manager.Common.Client.List(manager.Common.Ctx, podList, listOpts...)
+	if err != nil {
+		//An error occurred while retrieving the pods in our deployment.  Break control loop and return with error.
+		breakControl = true
+		manager.Common.Log.Error(err, "Failed to list pods", "Wordpress.Namespace", manager.Common.GetNamespace(), "Wordpress.Name", manager.Common.GetCustomResourceValue())
+		return breakControl, err
+	}
+
+	//The deployment pods have been retreived successfully.  Continue control loop.
+	return breakControl, err
+}

--- a/controllers/wordpress_controller.go
+++ b/controllers/wordpress_controller.go
@@ -16,77 +16,38 @@ package controllers
 
 import (
 	"context"
-	"github.com/go-logr/logr"
+	"github.com/James-Moore/wordpress-operator/controllers/common"
+	"github.com/James-Moore/wordpress-operator/controllers/deployment"
+	"github.com/James-Moore/wordpress-operator/controllers/pod"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/types"
-	"strconv"
-
 	//"reflect"
-
 	wordpressfullstackv1 "github.com/James-Moore/wordpress-operator/api/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-)
-
-const (
-	WordpressAppName       = "wordpress"
-	WordpressContainerName = "wordpress"
-	WordpressImageName     = "wordpress"
-
-	MySQLContainerName = "mysql"
-	MySQLImageName     = "mysql"
-
-	MySQL_MYSQLCNF_ConfigMapKey = "mysqlconfig"
-	MySQL_MYSQLCNF_ConfigVolume = "mysqlconfigvolume"
-	MySQL_MYSQLCNF_ConfigPath   = "/etc/mysql"
-	MySQL_MYSQLCNF_ConfigFile   = "mysql.cnf"
-
-	MySQL_SECURECHK_ConfigMapKey = "mysqlsecurecheck"
-	MySQL_SECURECHK_ConfigVolume = "mysqlsecurecheckvolume"
-	MySQL_SECURECHK_ConfigPath   = "/var/lib/mysql-files"
-	MySQL_SECURECHK_ConfigFile   = "blank.cnf"
-
-	MySQLPort       = "3306"
-	MySQLPort_INT32 = 3306
-
-	ServiceName = "wpservice"
 )
 
 func (r *WordpressReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
-	namespaceName := req.NamespacedName
-	log := r.Log.WithValues("wordpress", namespaceName)
-	ctx := context.Background()
+	//r.Common.Log = r.Common.Log.WithValues("wordpress", req.NamespacedName)
 
-	// Objects to be populated as pass by reference
-	wordpress := &wordpressfullstackv1.Wordpress{}
-	deployment := &appsv1.Deployment{}
-	podList := &corev1.PodList{}
+	r.Common.Log.Info("CHECKPOINT 1")
+	r.Common.Ctx = context.Background()
+	r.Common.Wordpress = &wordpressfullstackv1.Wordpress{}
 
-	log.Info("CHECKPOINT 1")
-	breakControl, err := r.reconcileCustomResource(ctx, namespaceName, wordpress)
+	breakControl, err := r.Common.Init(req.NamespacedName)
 	if breakControl {
 		return ctrl.Result{}, err
 	}
 
-	log.Info("CHECKPOINT 2")
-	breakControl, err = r.reconcileDeployment(ctx, wordpress, deployment)
+	r.Common.Log.Info("CHECKPOINT 2")
+	deploymentManager := &deployment.DeploymentManager{C: r.Common}
+	breakControl, err = deploymentManager.Reconcile()
 	if breakControl {
 		return ctrl.Result{}, err
 	}
 
-	// Update the Wordpress status with the pod names
-	log.Info("CHECKPOINT 3")
-	breakControl, err = r.getPodList(ctx, wordpress, podList)
-	if breakControl {
-		return ctrl.Result{}, err
-	}
-
-	log.Info("CHECKPOINT 4")
-	breakControl, err = r.reconcilePods(ctx, wordpress, podList)
+	r.Common.Log.Info("CHECKPOINT 3")
+	podManager := &pod.PodManager{Common: r.Common}
+	breakControl, err = podManager.Reconcile()
 	if breakControl {
 		return ctrl.Result{}, err
 	}
@@ -101,296 +62,8 @@ func (r *WordpressReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	//	}
 	//}
 
-	log.Info("CHECKPOINT 5")
+	r.Common.Log.Info("CHECKPOINT 4")
 	return ctrl.Result{}, nil
-}
-
-func (r *WordpressReconciler) getPodState(pod corev1.Pod) string {
-	message := "Pod: " + pod.Name
-	for _, containerStatus := range pod.Status.ContainerStatuses {
-		message = message + ", Container: " + containerStatus.Name + "State: " + containerStatus.State.String()
-	}
-	return message
-}
-
-func (r *WordpressReconciler) getPodsState(pods []corev1.Pod) string {
-	message := "Pods: "
-	for _, pod := range pods {
-		message += r.getPodState(pod)
-	}
-	return message
-}
-
-func (r *WordpressReconciler) containsContainer(containerName string, pod corev1.Pod) bool {
-	for _, cs := range pod.Status.ContainerStatuses {
-		if containerName == cs.Name {
-			return true
-		}
-	}
-	return false
-}
-
-func (r *WordpressReconciler) isContainerInPodReady(containerName string, pod corev1.Pod) bool {
-	ready := false
-	for _, cs := range pod.Status.ContainerStatuses {
-		if containerName == cs.Name {
-			ready = cs.Ready
-		}
-	}
-	return ready
-}
-
-//MySQLContainerName
-func (r *WordpressReconciler) isContainerInPodsReady(containerName string, podName string, pods []corev1.Pod) bool {
-	ready := false
-
-	r.Log.Info(r.getPodsState(pods))
-	for _, pod := range pods {
-		if (podName == pod.Name) && (r.containsContainer(containerName, pod)) {
-			ready = r.isContainerInPodReady(containerName, pod)
-			r.Log.Info("MySql Ready: " + strconv.FormatBool(ready))
-			return ready
-		}
-	}
-
-	return ready
-}
-
-func (r *WordpressReconciler) reconcilePods(ctx context.Context, wordpress *wordpressfullstackv1.Wordpress, podList *corev1.PodList) (breakControl bool, err error) {
-	breakControl = false
-	err = nil
-
-	mysqlReady := false
-
-	// TODO Get container name and pod name from the wordpress status to feed into isContainerPodsReady
-	//mysqlReady := r.isContainerInPodsReady()
-
-	//Nothing to reconcile if mysql is still booting in the container
-	if !mysqlReady {
-		breakControl = true
-		return breakControl, err
-	}
-
-	// TODO Add wordpress to deployment here
-	//, r.defineWordpressContainer(wordpress)
-
-	//podNames := getPodNames(podList.Items)
-	//Development statement:  Printing all pod names
-	//r.Log.Info("PRINTING POD NAMES: ")
-	//for podName, _ := range podNames {
-	//	r.Log.Info(podName)
-	//}
-
-	//switch os := len(podNames); os {
-	//case 0:
-	//	err := errors2.New("wordpress pod reconciliation error")
-	//	r.Log.Error(err, "WordpressContainer and MySQLContainer do not exist in deployment.  This should never happen.", "Wordpress.Namespace", wordpress.Namespace, "Wordpress.Name", wordpress.Name)
-	//	return err
-	//case 1:
-	//	if _, ok := podNames[WordpressImageName]; !ok {
-	//		err := errors2.New("wordpress pod reconciliation error")
-	//		r.Log.Error(err, "WordpressContainer exists without MySQLContainer.  This should never happen.", "Wordpress.Namespace", wordpress.Namespace, "Wordpress.Name", wordpress.Name)
-	//		return err
-	//	}
-	//	// TODO Update Deployment Definition here to include the wordpress container in the Pod.
-	//	// This becasue the mysqlpod is up and running
-	//default:
-	//	if os > 2 {
-	//		err := errors2.New("wordpress pod reconciliation error")
-	//		num := strconv.Itoa(os)
-	//		r.Log.Error(err, "There are additional pods that shoudl not exist in the Wordpress Deployment.  Number of pods are: "+num+".This should never happen.", "Wordpress.Namespace", wordpress.Namespace, "Wordpress.Name", wordpress.Name)
-	//		return err
-	//	}
-	//}
-
-	//Everything went fine.
-	return false, nil
-}
-
-// getPodNames returns the pod names of the array of pods passed in
-func getPodNames(pods []corev1.Pod) map[string]bool {
-	podNames := make(map[string]bool) // New empty set
-	//delete(podNames, "Foo")    // Delete
-	//exists := podNames["Foo"]  // Membership
-
-	for _, pod := range pods {
-		podNames[pod.Name] = true // Add
-	}
-	return podNames
-}
-
-func (r *WordpressReconciler) getPodList(ctx context.Context, wordpress *wordpressfullstackv1.Wordpress, podList *corev1.PodList) (breakControl bool, err error) {
-	breakControl = false
-	err = nil
-
-	// Define the values to match Pods against
-	listOpts := []client.ListOption{
-		client.InNamespace(wordpress.Namespace),
-		client.MatchingLabels(labelsForDeployment(wordpress.Name)),
-	}
-
-	// Get the list of pods matching our search parameters: Namespace and Labels
-	err = r.List(ctx, podList, listOpts...)
-	if err != nil {
-		//An error occurred while retrieving the pods in our deployment.  Break control loop and return with error.
-		breakControl = true
-		r.Log.Error(err, "Failed to list pods", "Wordpress.Namespace", wordpress.Namespace, "Wordpress.Name", wordpress.Name)
-		return breakControl, err
-	}
-
-	//The deployment pods have been retreived successfully.  Continue control loop.
-	return breakControl, err
-}
-
-func (r *WordpressReconciler) reconcileCustomResource(ctx context.Context, namespaceName types.NamespacedName, wordpress *wordpressfullstackv1.Wordpress) (breakControl bool, err error) {
-	breakControl = false
-	err = nil
-
-	// Fetch the Wordpress instance
-	err = r.Get(ctx, namespaceName, wordpress)
-	if err != nil {
-		breakControl = true
-
-		if errors.IsNotFound(err) {
-			// Request custom resource not found, could have been deleted after reconcile request.
-			// Owned objects are automatically garbage collected. For additional cleanup logic use finalizers.
-			// Return and don't requeue
-			r.Log.Info("Wordpress resource not found. Ignoring since object must be deleted")
-			err = nil
-			return breakControl, err
-		} else {
-			//The custom resource may exist.  We dont know in this case because an error was thrown while
-			//attempting cr retrieval.  Therefore we have to break control loop and exit.
-			r.Log.Error(err, "Failed to get Wordpress")
-			return breakControl, err
-		}
-	}
-
-	//Wordpress CR was retrieved successfully so do not break control loop.
-	return breakControl, err
-}
-
-func (r *WordpressReconciler) reconcileDeployment(ctx context.Context, wordpress *wordpressfullstackv1.Wordpress, deployment *appsv1.Deployment) (breakControl bool, err error) {
-	breakControl = false
-	err = nil
-
-	// Check if the deployment already exists, if not create a new one
-	err = r.Get(ctx, types.NamespacedName{Name: wordpress.Name, Namespace: wordpress.Namespace}, deployment)
-	if err != nil {
-
-		//If the deployment is not found create the deployment and disregard the error.  This is expected behavior.
-		if errors.IsNotFound(err) {
-			// Create the containers
-			r.Log.Info("Creating a new Deployment", "Deployment.Namespace", deployment.Namespace, "Deployment.Name", deployment.Name)
-
-			// Define a initial container in deployment.  We start with MySql
-			containers := []corev1.Container{r.defineWordpressContainer(wordpress), r.defineMySqlContainer(wordpress)}
-
-			// Define the deployment
-			deployment := r.defineDeployment(wordpress, containers)
-
-			// Set Wordpress instance as the owner and controller
-			ctrl.SetControllerReference(wordpress, deployment, r.Scheme)
-
-			err = r.Create(ctx, deployment)
-			if err != nil {
-				breakControl = true
-				r.Log.Error(err, "Failed to create new Deployment", "Deployment.Namespace", deployment.Namespace, "Deployment.Name", deployment.Name)
-				return breakControl, err
-			}
-
-			//TODO potentially assign Wordpress CR UID to Deployment as a label to allow searching for only this object
-			//Assign the wordpress deployment data to the status
-			wordpress.Status.WordpressDeploymentName = deployment.Name
-			wordpress.Status.WordpressDeploymentNamespace = deployment.Namespace
-			wordpress.Status.WordpressDeploymentUUID = string(deployment.UID)
-
-			//Assign the Wordpress pod data to the CR status
-			wordpress.Status.WordpressPodName = deployment.Spec.Template.Name
-			wordpress.Status.WordpressPodNamespace = deployment.Spec.Template.Namespace
-			wordpress.Status.WordpressPodUID = string(deployment.Spec.Template.UID)
-
-			//Assign the mysql container name to the cr status
-			//Note: We can index zero here only because we created the array and we know there is only 1 container
-			wordpress.Status.WordpressContainerName = deployment.Spec.Template.Spec.Containers[0].Name
-
-			//Must update wordpress cr to include added status values
-			err := r.Status().Update(ctx, wordpress)
-			if err != nil {
-				breakControl = true
-				r.Log.Error(err, "Failed to update Wordpress status")
-				return breakControl, err
-			}
-
-			// Deployment created successfully - disregard err - return and requeue
-			err = nil
-			return breakControl, err
-
-		} else {
-			//If the error is the result of anyting but not finding the deployment then
-			//an error was encountered when trying to get the deployment.  So exit control loop.
-			breakControl = true
-			r.Log.Error(err, "Failed to get Deployment")
-			return breakControl, err
-		}
-
-	}
-
-	//If we have arrived here then we have not encountered an error
-	//We have succesfully retrieved the deployment.  So continue control loop.
-	return breakControl, err
-}
-
-// deploymentForWordpress returns a wordpress Deployment object
-func (r *WordpressReconciler) defineDeployment(w *wordpressfullstackv1.Wordpress, containers []corev1.Container) *appsv1.Deployment {
-	ls := labelsForDeployment(w.Name)
-
-	dep := &appsv1.Deployment{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      w.Name,
-			Namespace: w.Namespace,
-		},
-		Spec: appsv1.DeploymentSpec{
-			//Replicas: replicas,
-			Selector: &metav1.LabelSelector{
-				MatchLabels: ls,
-			},
-			Template: corev1.PodTemplateSpec{
-				ObjectMeta: metav1.ObjectMeta{
-					Labels: ls,
-				},
-				Spec: corev1.PodSpec{
-					Volumes: []corev1.Volume{{
-						Name: MySQL_MYSQLCNF_ConfigVolume,
-						VolumeSource: corev1.VolumeSource{
-							ConfigMap: &corev1.ConfigMapVolumeSource{
-								LocalObjectReference: corev1.LocalObjectReference{Name: MySQL_MYSQLCNF_ConfigMapKey},
-								Items: []corev1.KeyToPath{{
-									Key:  MySQL_MYSQLCNF_ConfigFile,
-									Path: MySQL_MYSQLCNF_ConfigFile,
-								}},
-							},
-						},
-					},
-						{
-							Name: MySQL_SECURECHK_ConfigVolume,
-							VolumeSource: corev1.VolumeSource{
-								ConfigMap: &corev1.ConfigMapVolumeSource{
-									LocalObjectReference: corev1.LocalObjectReference{Name: MySQL_SECURECHK_ConfigMapKey},
-									Items: []corev1.KeyToPath{{
-										Key:  MySQL_SECURECHK_ConfigFile,
-										Path: MySQL_SECURECHK_ConfigFile,
-									}},
-								},
-							},
-						}},
-					Containers: containers,
-				},
-			},
-		},
-	}
-
-	return dep
 }
 
 // deploymentForWordpress returns a wordpress Deployment object
@@ -399,110 +72,25 @@ func updateDeploymentDefinition(deployment *appsv1.Deployment, container corev1.
 	deployment.Spec.Template.Spec.Containers = append(containers, container)
 }
 
-func (r *WordpressReconciler) defineWordpressContainer(m *wordpressfullstackv1.Wordpress) corev1.Container {
-
-	wordpressContainer := corev1.Container{
-		Name:  WordpressContainerName,
-		Image: WordpressImageName,
-		Ports: []corev1.ContainerPort{{
-			Name:          "wordpress",
-			ContainerPort: 80,
-		}},
-		Env: []corev1.EnvVar{
-			{
-				Name:  "WORDPRESS_DB_HOST",
-				Value: ServiceName + ":" + MySQLPort,
-			},
-			{
-				Name:  "WORDPRESS_DB_USER",
-				Value: "root",
-			},
-			{
-				Name:  "WORDPRESS_DB_PASSWORD",
-				Value: m.Spec.Password,
-			},
-			{
-				Name:  "WORDPRESS_DB_NAME",
-				Value: "wordpress",
-			},
-			{
-				Name:  "WORDPRESS_TABLE_PREFIX",
-				Value: "wp_",
-			},
-		},
-	}
-	return wordpressContainer
-}
-
-func (r *WordpressReconciler) defineMySqlContainer(m *wordpressfullstackv1.Wordpress) corev1.Container {
-
-	probeAction := &corev1.ExecAction{
-		Command: []string{"sh", "-c", "mysqladmin ping -u root -p${MYSQL_ROOT_PASSWORD}"},
-	}
-
-	probeHandler := corev1.Handler{
-		Exec: probeAction,
-	}
-
-	readinessProbe := &corev1.Probe{
-		Handler:             probeHandler,
-		InitialDelaySeconds: 10,
-		PeriodSeconds:       5,
-	}
-
-	mysqlContainer := corev1.Container{
-		Name:  MySQLContainerName,
-		Image: MySQLImageName,
-		Ports: []corev1.ContainerPort{{
-			Name:          "mysql",
-			ContainerPort: MySQLPort_INT32,
-		}},
-		Env: []corev1.EnvVar{{
-			Name:  "MYSQL_ROOT_PASSWORD",
-			Value: m.Spec.Password,
-		}},
-		VolumeMounts: []corev1.VolumeMount{{
-			Name:      MySQL_MYSQLCNF_ConfigVolume,
-			MountPath: MySQL_MYSQLCNF_ConfigPath,
-		},
-			{
-				Name:      MySQL_SECURECHK_ConfigVolume,
-				MountPath: MySQL_SECURECHK_ConfigPath,
-			},
-		},
-		ReadinessProbe: readinessProbe,
-	}
-
-	return mysqlContainer
-}
-
-// labelsForWordpress returns the labels for selecting the resources
-// belonging to the given wordpress CR name.
-func labelsForDeployment(name string) map[string]string {
-	return map[string]string{"app": WordpressAppName, "wordpress_cr": name}
-}
-
 func (r *WordpressReconciler) SetupWithManager(mgr ctrl.Manager) error {
-	builder := ctrl.NewControllerManagedBy(mgr)
-	builder = builder.For(&wordpressfullstackv1.Wordpress{})
-	builder = builder.Owns(&appsv1.Deployment{})
-	return builder.Complete(r)
+	//builder := ctrl.NewControllerManagedBy(mgr)
+	//builder = builder.For(&wordpressfullstackv1.Wordpress{})
+	//builder = builder.Owns(&appsv1.Deployment{})
+	//return builder.Complete(r)
 
-	//return ctrl.NewControllerManagedBy(mgr).
-	//	For(&wordpressfullstackv1.Wordpress{}).
-	//	Owns(&appsv1.Deployment{}).
-	//	Complete(r)
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&wordpressfullstackv1.Wordpress{}).
+		Owns(&appsv1.Deployment{}).
+		Complete(r)
 
 }
 
-// +kubebuilder:rbac:groups=cache.example.com,resources=wordpresss,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=cache.example.com,resources=wordpresss/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=wordpress-fullstack.jamesmoore.in,resources=wordpresss,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=wordpress-fullstack.jamesmoore.in,resources=wordpresss/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=core,resources=pods,verbs=get;list;
 
 // WordpressReconciler reconciles a Wordpress object
 type WordpressReconciler struct {
-	client.Client
-	Log    logr.Logger
-	Scheme *runtime.Scheme
+	Common *common.Common
 }

--- a/controllers/wordpress_controller.txt
+++ b/controllers/wordpress_controller.txt
@@ -417,8 +417,8 @@ func (r *WordpressReconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 }
 
-// +kubebuilder:rbac:groups=cache.example.com,resources=wordpresss,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=cache.example.com,resources=wordpresss/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=wordpress-fullstack.jamesmoore.in,resources=wordpresss,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=wordpress-fullstack.jamesmoore.in,resources=wordpresss/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=core,resources=pods,verbs=get;list;
 

--- a/go.mod
+++ b/go.mod
@@ -3,11 +3,12 @@ module github.com/James-Moore/wordpress-operator
 go 1.13
 
 require (
+	github.com/ghodss/yaml v1.0.0
 	github.com/go-logr/logr v0.1.0
 	github.com/onsi/ginkgo v1.12.1
 	github.com/onsi/gomega v1.10.1
-	k8s.io/api v0.18.6
-	k8s.io/apimachinery v0.18.6
+	k8s.io/api v0.18.8
+	k8s.io/apimachinery v0.18.8
 	k8s.io/client-go v0.18.6
 	sigs.k8s.io/controller-runtime v0.6.2
 )

--- a/go.sum
+++ b/go.sum
@@ -60,6 +60,7 @@ github.com/emicklei/go-restful v0.0.0-20170410110728-ff4f55a20633/go.mod h1:otzb
 github.com/emicklei/go-restful v2.9.5+incompatible/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
+github.com/evanphx/json-patch v0.0.0-20200808040245-162e5629780b/go.mod h1:NAJj0yf/KaRKURN6nyi7A9IZydMivZEm9oQLWNjfKDc=
 github.com/evanphx/json-patch v4.2.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/evanphx/json-patch v4.5.0+incompatible h1:ouOWdg56aJriqS0huScTkVXPC5IcNrDCXZ6OoTAWu7M=
 github.com/evanphx/json-patch v4.5.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
@@ -68,6 +69,7 @@ github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMo
 github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWoS4=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
 github.com/ghodss/yaml v0.0.0-20150909031657-73d445a93680/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
+github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/globalsign/mgo v0.0.0-20180905125535-1ca0a4f7cbcb/go.mod h1:xkRDCp4j0OGD1HRkm4kmhM+pmpv3AKq5SU7GMg4oO/Q=
 github.com/globalsign/mgo v0.0.0-20181015135952-eeefdecb41b8/go.mod h1:xkRDCp4j0OGD1HRkm4kmhM+pmpv3AKq5SU7GMg4oO/Q=
@@ -179,6 +181,7 @@ github.com/imdario/mergo v0.3.5/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJ
 github.com/imdario/mergo v0.3.9 h1:UauaLniWCFHWd+Jp9oCEkTBj8VO/9DKg3PV3VCNMDIg=
 github.com/imdario/mergo v0.3.9/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
+github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/json-iterator/go v1.1.7/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
@@ -442,10 +445,14 @@ honnef.co/go/tools v0.0.0-20190106161140-3f1c8253044a/go.mod h1:rf3lG4BRIbNafJWh
 honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 k8s.io/api v0.18.6 h1:osqrAXbOQjkKIWDTjrqxWQ3w0GkKb1KA1XkUGHHYpeE=
 k8s.io/api v0.18.6/go.mod h1:eeyxr+cwCjMdLAmr2W3RyDI0VvTawSg/3RFFBEnmZGI=
+k8s.io/api v0.18.8 h1:aIKUzJPb96f3fKec2lxtY7acZC9gQNDLVhfSGpxBAC4=
+k8s.io/api v0.18.8/go.mod h1:d/CXqwWv+Z2XEG1LgceeDmHQwpUJhROPx16SlxJgERY=
 k8s.io/apiextensions-apiserver v0.18.6 h1:vDlk7cyFsDyfwn2rNAO2DbmUbvXy5yT5GE3rrqOzaMo=
 k8s.io/apiextensions-apiserver v0.18.6/go.mod h1:lv89S7fUysXjLZO7ke783xOwVTm6lKizADfvUM/SS/M=
 k8s.io/apimachinery v0.18.6 h1:RtFHnfGNfd1N0LeSrKCUznz5xtUP1elRGvHJbL3Ntag=
 k8s.io/apimachinery v0.18.6/go.mod h1:OaXp26zu/5J7p0f92ASynJa1pZo06YlV9fG7BoWbCko=
+k8s.io/apimachinery v0.18.8 h1:jimPrycCqgx2QPearX3to1JePz7wSbVLq+7PdBTTwQ0=
+k8s.io/apimachinery v0.18.8/go.mod h1:6sQd+iHEqmOtALqOFjSWp2KZ9F0wlU/nWm0ZgsYWMig=
 k8s.io/apiserver v0.18.6/go.mod h1:Zt2XvTHuaZjBz6EFYzpp+X4hTmgWGy8AthNVnTdm3Wg=
 k8s.io/client-go v0.18.6 h1:I+oWqJbibLSGsZj8Xs8F0aWVXJVIoUHWaaJV3kUN/Zw=
 k8s.io/client-go v0.18.6/go.mod h1:/fwtGLjYMS1MaM5oi+eXhKwG+1UHidUEXRh6cNsdO0Q=

--- a/main.go
+++ b/main.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"flag"
+	"github.com/James-Moore/wordpress-operator/controllers/common"
 	"os"
 
 	"k8s.io/apimachinery/pkg/runtime"
@@ -68,9 +69,11 @@ func main() {
 	}
 
 	if err = (&controllers.WordpressReconciler{
-		Client: mgr.GetClient(),
-		Log:    ctrl.Log.WithName("controllers").WithName("Wordpress"),
-		Scheme: mgr.GetScheme(),
+		Common: &common.Common{
+			Client: mgr.GetClient(),
+			Log:    ctrl.Log.WithName("controllers").WithName("Wordpress"),
+			Scheme: mgr.GetScheme(),
+		},
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Wordpress")
 		os.Exit(1)


### PR DESCRIPTION
Cleaned the code to make it more modular and maintainable.  It is no longer a mishmosh of stuff from the generated operator-sdk example, but still has to have the ingress, service, etc added in to golang